### PR TITLE
feat: remove azurenoops provider dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 # Azure Management Virtual Network Hub Overlay with Firewall Terraform Module
 
-[![Changelog](https://img.shields.io/badge/changelog-release-green.svg)](CHANGELOG.md) [![Notice](https://img.shields.io/badge/notice-copyright-yellow.svg)](NOTICE) [![MIT License](https://img.shields.io/badge/license-MIT-orange.svg)](LICENSE) [![TF Registry](https://img.shields.io/badge/terraform-registry-blue.svg)](https://registry.terraform.io/modules/azurenoops/overlays-management-hub/azurerm/)
+[![Changelog](https://img.shields.io/badge/changelog-release-green.svg)](CHANGELOG.md) [![Notice](https://img.shields.io/badge/notice-copyright-yellow.svg)](NOTICE) [![MIT License](https://img.shields.io/badge/license-MIT-orange.svg)](LICENSE) [![TF Registry](https://img.shields.io/badge/terraform-registry-blue.svg)](https://registry.terraform.io/modules/POps-Rox/overlays-management-hub/azurerm/)
 
 This Terraform module deploys a Management Virtual Network Hub Overlay using the [Microsoft recommended Hub-Spoke network topology](https://docs.microsoft.com/en-us/azure/architecture/reference-architectures/hybrid-networking/hub-spoke). Usually, only one hub in each region with multiple spokes and each of the spokes can also be in separate subscriptions.
 
@@ -653,7 +653,7 @@ If you want to remotely access the network and the resources you've deployed you
 
 By default, this module will not create a Azure Bastion Host. You can enable/disable it by appending an argument `enable_bastion_host` located in `variables.bastion.tf` If you want to enable a Azure Bastion Host using this module, set argument `enable_bastion_host = true`.
 
-If you would like to create a jumpbox VM in the network, you can use the [Azure Bastion Jumpbox](https://registry.terraform.io/modules/azurenoops/overlays-virtual-machine/azurerm/latest) Virtual Machine module.
+If you would like to create a jumpbox VM in the network, you can use the [Azure Bastion Jumpbox](https://registry.terraform.io/modules/POps-Rox/overlays-virtual-machine/azurerm/latest) Virtual Machine module.
 
 ## Azure Firewall Premium
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,7 +8,7 @@
 
 # Azure Management Virtual Network Hub Overlay with Firewall Terraform Module
 
-[![Changelog](https://img.shields.io/badge/changelog-release-green.svg)](CHANGELOG.md) [![Notice](https://img.shields.io/badge/notice-copyright-yellow.svg)](NOTICE) [![MIT License](https://img.shields.io/badge/license-MIT-orange.svg)](LICENSE) [![TF Registry](https://img.shields.io/badge/terraform-registry-blue.svg)](https://registry.terraform.io/modules/azurenoops/overlays-management-hub/azurerm/)
+[![Changelog](https://img.shields.io/badge/changelog-release-green.svg)](CHANGELOG.md) [![Notice](https://img.shields.io/badge/notice-copyright-yellow.svg)](NOTICE) [![MIT License](https://img.shields.io/badge/license-MIT-orange.svg)](LICENSE) [![TF Registry](https://img.shields.io/badge/terraform-registry-blue.svg)](https://registry.terraform.io/modules/POps-Rox/overlays-management-hub/azurerm/)
 
 This Terraform module deploys a Management Virtual Network Hub Overlay using the [Microsoft recommended Hub-Spoke network topology](https://docs.microsoft.com/en-us/azure/architecture/reference-architectures/hybrid-networking/hub-spoke). Usually, only one hub in each region with multiple spokes and each of the spokes can also be in separate subscriptions.
 
@@ -653,7 +653,7 @@ If you want to remotely access the network and the resources you've deployed you
 
 By default, this module will not create a Azure Bastion Host. You can enable/disable it by appending an argument `enable_bastion_host` located in `variables.bastion.tf` If you want to enable a Azure Bastion Host using this module, set argument `enable_bastion_host = true`.
 
-If you would like to create a jumpbox VM in the network, you can use the [Azure Bastion Jumpbox](https://registry.terraform.io/modules/azurenoops/overlays-virtual-machine/azurerm/latest) Virtual Machine module.
+If you would like to create a jumpbox VM in the network, you can use the [Azure Bastion Jumpbox](https://registry.terraform.io/modules/POps-Rox/overlays-virtual-machine/azurerm/latest) Virtual Machine module.
 
 ## Azure Firewall Premium
 

--- a/examples/Commerical/hub_w_force_tunnel_and_ddos/README.md
+++ b/examples/Commerical/hub_w_force_tunnel_and_ddos/README.md
@@ -9,7 +9,7 @@ provider "azurerm" {
 }
 
 module "mod_vnet_hub" {
-  source  = "azurenoops/overlays-management-hub/azurerm"
+  source  = "POps-Rox/overlays-management-hub/azurerm"
   version = "x.x.x"
 
   ################################

--- a/examples/Commerical/hub_w_force_tunnel_ddos_encrypted_transport/README.md
+++ b/examples/Commerical/hub_w_force_tunnel_ddos_encrypted_transport/README.md
@@ -9,7 +9,7 @@ provider "azurerm" {
 }
 
 module "mod_vnet_hub" {
-  source  = "azurenoops/overlays-management-hub/azurerm"
+  source  = "POps-Rox/overlays-management-hub/azurerm"
   version = "x.x.x"
 
   ################################

--- a/examples/Commerical/hub_w_no_force_tunnel/README.md
+++ b/examples/Commerical/hub_w_no_force_tunnel/README.md
@@ -9,7 +9,7 @@ provider "azurerm" {
 }
 
 module "mod_vnet_hub" {
-  #source  = "azurenoops/overlays-management-hub/azurerm"
+  #source  = "POps-Rox/overlays-management-hub/azurerm"
   #version = "x.x.x"
   source = "../../.."
 

--- a/examples/Government/hub_w_force_tunnel_and_dns/README.md
+++ b/examples/Government/hub_w_force_tunnel_and_dns/README.md
@@ -9,7 +9,7 @@ provider "azurerm" {
 }
 
 module "mod_vnet_hub" {
-  source  = "azurenoops/overlays-management-hub/azurerm"
+  source  = "POps-Rox/overlays-management-hub/azurerm"
   version = "x.x.x"
 
   ################################

--- a/examples/Government/hub_w_force_tunnel_and_dns_cmk/README.md
+++ b/examples/Government/hub_w_force_tunnel_and_dns_cmk/README.md
@@ -9,7 +9,7 @@ provider "azurerm" {
 }
 
 module "mod_vnet_hub" {
-  #source  = "azurenoops/overlays-management-hub/azurerm"
+  #source  = "POps-Rox/overlays-management-hub/azurerm"
   #version = "x.x.x"
   source = "../../.."
 

--- a/examples/Government/hub_w_no_force_tunnel/README.md
+++ b/examples/Government/hub_w_no_force_tunnel/README.md
@@ -9,7 +9,7 @@ provider "azurerm" {
 }
 
 module "mod_vnet_hub" {
-  #source  = "azurenoops/overlays-management-hub/azurerm"
+  #source  = "POps-Rox/overlays-management-hub/azurerm"
   #version = "x.x.x"
   source = "../../.." # For Example, use the relative path to the module
 

--- a/locals.naming.tf
+++ b/locals.naming.tf
@@ -8,24 +8,24 @@ locals {
 
   resource_group_name          = element(coalescelist(data.azurerm_resource_group.rgrp[*].name, module.mod_scaffold_rg[*].resource_group_name, [""]), 0)
   location                     = element(coalescelist(data.azurerm_resource_group.rgrp[*].location, module.mod_scaffold_rg[*].resource_group_location, [""]), 0)
-  hub_vnet_name                = coalesce(var.hub_vnet_custom_name, data.popsrox_utils_resource_name.vnet.result)
-  hub_firewall_name            = coalesce(var.hub_firewall_custom_name, data.popsrox_utils_resource_name.firewall.result)
-  hub_firewall_policy_name     = coalesce(var.hub_firewall_policy_custom_name, data.popsrox_utils_resource_name.firewall_policy.result)
-  hub_firewall_client_pip_name = coalesce(var.hub_firewall_client_pip_custom_name, data.popsrox_utils_resource_name.firewall_client_pub_ip.result)
-  hub_firewall_mgt_pip_name    = coalesce(var.hub_firewall_mgt_pip_custom_name, data.popsrox_utils_resource_name.firewall_mgt_pub_ip.result)
-  hub_rt_name                  = coalesce(var.hub_routetable_custom_name, data.popsrox_utils_resource_name.rt.result)
-  hub_afw_rt_name              = coalesce(var.hub_routetable_custom_name, data.popsrox_utils_resource_name.afw_rt.result)
-  hub_sa_name                  = coalesce(var.hub_sa_custom_name, data.popsrox_utils_resource_name.st.result)
+  hub_vnet_name                = coalesce(var.hub_vnet_custom_name, data.popsrox_resource_name.vnet.result)
+  hub_firewall_name            = coalesce(var.hub_firewall_custom_name, data.popsrox_resource_name.firewall.result)
+  hub_firewall_policy_name     = coalesce(var.hub_firewall_policy_custom_name, data.popsrox_resource_name.firewall_policy.result)
+  hub_firewall_client_pip_name = coalesce(var.hub_firewall_client_pip_custom_name, data.popsrox_resource_name.firewall_client_pub_ip.result)
+  hub_firewall_mgt_pip_name    = coalesce(var.hub_firewall_mgt_pip_custom_name, data.popsrox_resource_name.firewall_mgt_pub_ip.result)
+  hub_rt_name                  = coalesce(var.hub_routetable_custom_name, data.popsrox_resource_name.rt.result)
+  hub_afw_rt_name              = coalesce(var.hub_routetable_custom_name, data.popsrox_resource_name.afw_rt.result)
+  hub_sa_name                  = coalesce(var.hub_sa_custom_name, data.popsrox_resource_name.st.result)
 
   # DDOS Protection Plan
-  ddos_plan_name = coalesce(var.ddos_plan_custom_name, data.popsrox_utils_resource_name.ddos.result)
+  ddos_plan_name = coalesce(var.ddos_plan_custom_name, data.popsrox_resource_name.ddos.result)
 
   # Bastion Host
-  bastion_name     = coalesce(var.bastion_custom_name, data.popsrox_utils_resource_name.bastion.result)
-  bastion_pip_name = coalesce(var.bastion_pip_custom_name, data.popsrox_utils_resource_name.bastion_pip.result)
+  bastion_name     = coalesce(var.bastion_custom_name, data.popsrox_resource_name.bastion.result)
+  bastion_pip_name = coalesce(var.bastion_pip_custom_name, data.popsrox_resource_name.bastion_pip.result)
 
   # Private Endpoint
-  pe_name  = data.popsrox_utils_resource_name.pe.result
-  psc_name = data.popsrox_utils_resource_name.psc.result
-  nic_name = data.popsrox_utils_resource_name.nic.result
+  pe_name  = data.popsrox_resource_name.pe.result
+  psc_name = data.popsrox_resource_name.psc.result
+  nic_name = data.popsrox_resource_name.nic.result
 }

--- a/locals.naming.tf
+++ b/locals.naming.tf
@@ -8,24 +8,24 @@ locals {
 
   resource_group_name          = element(coalescelist(data.azurerm_resource_group.rgrp[*].name, module.mod_scaffold_rg[*].resource_group_name, [""]), 0)
   location                     = element(coalescelist(data.azurerm_resource_group.rgrp[*].location, module.mod_scaffold_rg[*].resource_group_location, [""]), 0)
-  hub_vnet_name                = coalesce(var.hub_vnet_custom_name, data.azurenoopsutils_resource_name.vnet.result)
-  hub_firewall_name            = coalesce(var.hub_firewall_custom_name, data.azurenoopsutils_resource_name.firewall.result)
-  hub_firewall_policy_name     = coalesce(var.hub_firewall_policy_custom_name, data.azurenoopsutils_resource_name.firewall_policy.result)
-  hub_firewall_client_pip_name = coalesce(var.hub_firewall_client_pip_custom_name, data.azurenoopsutils_resource_name.firewall_client_pub_ip.result)
-  hub_firewall_mgt_pip_name    = coalesce(var.hub_firewall_mgt_pip_custom_name, data.azurenoopsutils_resource_name.firewall_mgt_pub_ip.result)
-  hub_rt_name                  = coalesce(var.hub_routetable_custom_name, data.azurenoopsutils_resource_name.rt.result)
-  hub_afw_rt_name              = coalesce(var.hub_routetable_custom_name, data.azurenoopsutils_resource_name.afw_rt.result)
-  hub_sa_name                  = coalesce(var.hub_sa_custom_name, data.azurenoopsutils_resource_name.st.result)
+  hub_vnet_name                = coalesce(var.hub_vnet_custom_name, data.popsrox_utils_resource_name.vnet.result)
+  hub_firewall_name            = coalesce(var.hub_firewall_custom_name, data.popsrox_utils_resource_name.firewall.result)
+  hub_firewall_policy_name     = coalesce(var.hub_firewall_policy_custom_name, data.popsrox_utils_resource_name.firewall_policy.result)
+  hub_firewall_client_pip_name = coalesce(var.hub_firewall_client_pip_custom_name, data.popsrox_utils_resource_name.firewall_client_pub_ip.result)
+  hub_firewall_mgt_pip_name    = coalesce(var.hub_firewall_mgt_pip_custom_name, data.popsrox_utils_resource_name.firewall_mgt_pub_ip.result)
+  hub_rt_name                  = coalesce(var.hub_routetable_custom_name, data.popsrox_utils_resource_name.rt.result)
+  hub_afw_rt_name              = coalesce(var.hub_routetable_custom_name, data.popsrox_utils_resource_name.afw_rt.result)
+  hub_sa_name                  = coalesce(var.hub_sa_custom_name, data.popsrox_utils_resource_name.st.result)
 
   # DDOS Protection Plan
-  ddos_plan_name = coalesce(var.ddos_plan_custom_name, data.azurenoopsutils_resource_name.ddos.result)
+  ddos_plan_name = coalesce(var.ddos_plan_custom_name, data.popsrox_utils_resource_name.ddos.result)
 
   # Bastion Host
-  bastion_name     = coalesce(var.bastion_custom_name, data.azurenoopsutils_resource_name.bastion.result)
-  bastion_pip_name = coalesce(var.bastion_pip_custom_name, data.azurenoopsutils_resource_name.bastion_pip.result)
+  bastion_name     = coalesce(var.bastion_custom_name, data.popsrox_utils_resource_name.bastion.result)
+  bastion_pip_name = coalesce(var.bastion_pip_custom_name, data.popsrox_utils_resource_name.bastion_pip.result)
 
   # Private Endpoint
-  pe_name  = data.azurenoopsutils_resource_name.pe.result
-  psc_name = data.azurenoopsutils_resource_name.psc.result
-  nic_name = data.azurenoopsutils_resource_name.nic.result
+  pe_name  = data.popsrox_utils_resource_name.pe.result
+  psc_name = data.popsrox_utils_resource_name.psc.result
+  nic_name = data.popsrox_utils_resource_name.nic.result
 }

--- a/modules.management.hub.nsg.tf
+++ b/modules.management.hub.nsg.tf
@@ -14,7 +14,7 @@ module "nsg" {
 
   for_each = var.hub_subnets
 
-  name                = var.hub_nsg_custom_name != null ? format("%s_%s", var.hub_nsg_custom_name, each.key) : data.azurenoopsutils_resource_name.nsg[each.key].result
+  name                = var.hub_nsg_custom_name != null ? format("%s_%s", var.hub_nsg_custom_name, each.key) : data.popsrox_utils_resource_name.nsg[each.key].result
   resource_group_name = local.resource_group_name
   location            = local.location
   tags                = merge({ "ResourceName" = lower("nsg_${each.key}") }, local.default_tags, var.add_tags, )

--- a/modules.management.hub.nsg.tf
+++ b/modules.management.hub.nsg.tf
@@ -14,7 +14,7 @@ module "nsg" {
 
   for_each = var.hub_subnets
 
-  name                = var.hub_nsg_custom_name != null ? format("%s_%s", var.hub_nsg_custom_name, each.key) : data.popsrox_utils_resource_name.nsg[each.key].result
+  name                = var.hub_nsg_custom_name != null ? format("%s_%s", var.hub_nsg_custom_name, each.key) : data.popsrox_resource_name.nsg[each.key].result
   resource_group_name = local.resource_group_name
   location            = local.location
   tags                = merge({ "ResourceName" = lower("nsg_${each.key}") }, local.default_tags, var.add_tags, )

--- a/modules.management.hub.snet.tf
+++ b/modules.management.hub.snet.tf
@@ -40,7 +40,7 @@ module "default_snet" {
   for_each   = var.hub_subnets
 
   # Resource Name
-  name = var.hub_snet_custom_name != null ? format("%s-%s", var.hub_snet_custom_name, each.key) : data.azurenoopsutils_resource_name.snet[each.key].result
+  name = var.hub_snet_custom_name != null ? format("%s-%s", var.hub_snet_custom_name, each.key) : data.popsrox_utils_resource_name.snet[each.key].result
 
   # Virtual Networks
   virtual_network = {

--- a/modules.management.hub.snet.tf
+++ b/modules.management.hub.snet.tf
@@ -40,7 +40,7 @@ module "default_snet" {
   for_each   = var.hub_subnets
 
   # Resource Name
-  name = var.hub_snet_custom_name != null ? format("%s-%s", var.hub_snet_custom_name, each.key) : data.popsrox_utils_resource_name.snet[each.key].result
+  name = var.hub_snet_custom_name != null ? format("%s-%s", var.hub_snet_custom_name, each.key) : data.popsrox_resource_name.snet[each.key].result
 
   # Virtual Networks
   virtual_network = {

--- a/naming.tf
+++ b/naming.tf
@@ -6,7 +6,7 @@ resource "random_id" "id" {
   byte_length = 3
 }
 
-data "popsrox_utils_resource_name" "vnet" {
+data "popsrox_resource_name" "vnet" {
   name          = var.workload_name
   resource_type = "azurerm_virtual_network"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : module.mod_azregions.location_cli]
@@ -16,7 +16,7 @@ data "popsrox_utils_resource_name" "vnet" {
   separator     = "-"
 }
 
-data "popsrox_utils_resource_name" "firewall" {
+data "popsrox_resource_name" "firewall" {
   name          = var.workload_name
   resource_type = "azurerm_firewall"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : module.mod_azregions.location_cli]
@@ -26,7 +26,7 @@ data "popsrox_utils_resource_name" "firewall" {
   separator     = "-"
 }
 
-data "popsrox_utils_resource_name" "firewall_policy" {
+data "popsrox_resource_name" "firewall_policy" {
   name          = var.workload_name
   resource_type = "azurerm_firewall_policy"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : module.mod_azregions.location_cli]
@@ -36,7 +36,7 @@ data "popsrox_utils_resource_name" "firewall_policy" {
   separator     = "-"
 }
 
-data "popsrox_utils_resource_name" "snet" {
+data "popsrox_resource_name" "snet" {
   for_each      = var.hub_subnets
   name          = var.workload_name
   resource_type = "azurerm_subnet"
@@ -47,7 +47,7 @@ data "popsrox_utils_resource_name" "snet" {
   separator     = "-"
 }
 
-data "popsrox_utils_resource_name" "firewall_client_pub_ip" {
+data "popsrox_resource_name" "firewall_client_pub_ip" {
   name          = var.workload_name
   resource_type = "azurerm_public_ip"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : module.mod_azregions.location_cli]
@@ -57,7 +57,7 @@ data "popsrox_utils_resource_name" "firewall_client_pub_ip" {
   separator     = "-"
 }
 
-data "popsrox_utils_resource_name" "firewall_mgt_pub_ip" {
+data "popsrox_resource_name" "firewall_mgt_pub_ip" {
   name          = var.workload_name
   resource_type = "azurerm_public_ip"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : module.mod_azregions.location_cli]
@@ -67,7 +67,7 @@ data "popsrox_utils_resource_name" "firewall_mgt_pub_ip" {
   separator     = "-"
 }
 
-data "popsrox_utils_resource_name" "nsg" {
+data "popsrox_resource_name" "nsg" {
   for_each      = var.hub_subnets
   name          = var.workload_name
   resource_type = "azurerm_network_security_group"
@@ -78,7 +78,7 @@ data "popsrox_utils_resource_name" "nsg" {
   separator     = "-"
 }
 
-data "popsrox_utils_resource_name" "rt" {
+data "popsrox_resource_name" "rt" {
   name          = var.workload_name
   resource_type = "azurerm_route_table"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : module.mod_azregions.location_cli]
@@ -88,7 +88,7 @@ data "popsrox_utils_resource_name" "rt" {
   separator     = "-"
 }
 
-data "popsrox_utils_resource_name" "afw_rt" {
+data "popsrox_resource_name" "afw_rt" {
   name          = var.workload_name
   resource_type = "azurerm_route_table"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : module.mod_azregions.location_cli]
@@ -98,7 +98,7 @@ data "popsrox_utils_resource_name" "afw_rt" {
   separator     = "-"
 }
 
-data "popsrox_utils_resource_name" "st" {
+data "popsrox_resource_name" "st" {
   name          = random_id.uniqueString.hex
   resource_type = "azurerm_storage_account"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : module.mod_azregions.location_cli]
@@ -106,7 +106,7 @@ data "popsrox_utils_resource_name" "st" {
   use_slug      = var.use_naming
 }
 
-data "popsrox_utils_resource_name" "bastion" {
+data "popsrox_resource_name" "bastion" {
   name          = var.workload_name
   resource_type = "azurerm_bastion_host"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : module.mod_azregions.location_cli]
@@ -116,7 +116,7 @@ data "popsrox_utils_resource_name" "bastion" {
   separator     = "-"
 }
 
-data "popsrox_utils_resource_name" "bastion_pip" {
+data "popsrox_resource_name" "bastion_pip" {
   name          = var.workload_name
   resource_type = "azurerm_public_ip"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : module.mod_azregions.location_cli]
@@ -126,7 +126,7 @@ data "popsrox_utils_resource_name" "bastion_pip" {
   separator     = "-"
 }
 
-data "popsrox_utils_resource_name" "ddos" {
+data "popsrox_resource_name" "ddos" {
   name          = var.workload_name
   resource_type = "azurerm_network_ddos_protection_plan"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : module.mod_azregions.location_cli]
@@ -136,7 +136,7 @@ data "popsrox_utils_resource_name" "ddos" {
   separator     = "-"
 }
 
-data "popsrox_utils_resource_name" "pe" {
+data "popsrox_resource_name" "pe" {
   name          = var.workload_name
   resource_type = "azurerm_private_endpoint"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : module.mod_azregions.location_cli]
@@ -146,7 +146,7 @@ data "popsrox_utils_resource_name" "pe" {
   separator     = "-"
 }
 
-data "popsrox_utils_resource_name" "psc" {
+data "popsrox_resource_name" "psc" {
   name          = var.workload_name
   resource_type = "azurerm_private_service_connection"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : module.mod_azregions.location_cli]
@@ -156,7 +156,7 @@ data "popsrox_utils_resource_name" "psc" {
   separator     = "-"
 }
 
-data "popsrox_utils_resource_name" "nic" {
+data "popsrox_resource_name" "nic" {
   name          = var.workload_name
   resource_type = "azurerm_network_interface"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : module.mod_azregions.location_cli]

--- a/naming.tf
+++ b/naming.tf
@@ -6,7 +6,7 @@ resource "random_id" "id" {
   byte_length = 3
 }
 
-data "azurenoopsutils_resource_name" "vnet" {
+data "popsrox_utils_resource_name" "vnet" {
   name          = var.workload_name
   resource_type = "azurerm_virtual_network"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : module.mod_azregions.location_cli]
@@ -16,7 +16,7 @@ data "azurenoopsutils_resource_name" "vnet" {
   separator     = "-"
 }
 
-data "azurenoopsutils_resource_name" "firewall" {
+data "popsrox_utils_resource_name" "firewall" {
   name          = var.workload_name
   resource_type = "azurerm_firewall"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : module.mod_azregions.location_cli]
@@ -26,7 +26,7 @@ data "azurenoopsutils_resource_name" "firewall" {
   separator     = "-"
 }
 
-data "azurenoopsutils_resource_name" "firewall_policy" {
+data "popsrox_utils_resource_name" "firewall_policy" {
   name          = var.workload_name
   resource_type = "azurerm_firewall_policy"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : module.mod_azregions.location_cli]
@@ -36,7 +36,7 @@ data "azurenoopsutils_resource_name" "firewall_policy" {
   separator     = "-"
 }
 
-data "azurenoopsutils_resource_name" "snet" {
+data "popsrox_utils_resource_name" "snet" {
   for_each      = var.hub_subnets
   name          = var.workload_name
   resource_type = "azurerm_subnet"
@@ -47,7 +47,7 @@ data "azurenoopsutils_resource_name" "snet" {
   separator     = "-"
 }
 
-data "azurenoopsutils_resource_name" "firewall_client_pub_ip" {
+data "popsrox_utils_resource_name" "firewall_client_pub_ip" {
   name          = var.workload_name
   resource_type = "azurerm_public_ip"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : module.mod_azregions.location_cli]
@@ -57,7 +57,7 @@ data "azurenoopsutils_resource_name" "firewall_client_pub_ip" {
   separator     = "-"
 }
 
-data "azurenoopsutils_resource_name" "firewall_mgt_pub_ip" {
+data "popsrox_utils_resource_name" "firewall_mgt_pub_ip" {
   name          = var.workload_name
   resource_type = "azurerm_public_ip"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : module.mod_azregions.location_cli]
@@ -67,7 +67,7 @@ data "azurenoopsutils_resource_name" "firewall_mgt_pub_ip" {
   separator     = "-"
 }
 
-data "azurenoopsutils_resource_name" "nsg" {
+data "popsrox_utils_resource_name" "nsg" {
   for_each      = var.hub_subnets
   name          = var.workload_name
   resource_type = "azurerm_network_security_group"
@@ -78,7 +78,7 @@ data "azurenoopsutils_resource_name" "nsg" {
   separator     = "-"
 }
 
-data "azurenoopsutils_resource_name" "rt" {
+data "popsrox_utils_resource_name" "rt" {
   name          = var.workload_name
   resource_type = "azurerm_route_table"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : module.mod_azregions.location_cli]
@@ -88,7 +88,7 @@ data "azurenoopsutils_resource_name" "rt" {
   separator     = "-"
 }
 
-data "azurenoopsutils_resource_name" "afw_rt" {
+data "popsrox_utils_resource_name" "afw_rt" {
   name          = var.workload_name
   resource_type = "azurerm_route_table"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : module.mod_azregions.location_cli]
@@ -98,7 +98,7 @@ data "azurenoopsutils_resource_name" "afw_rt" {
   separator     = "-"
 }
 
-data "azurenoopsutils_resource_name" "st" {
+data "popsrox_utils_resource_name" "st" {
   name          = random_id.uniqueString.hex
   resource_type = "azurerm_storage_account"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : module.mod_azregions.location_cli]
@@ -106,7 +106,7 @@ data "azurenoopsutils_resource_name" "st" {
   use_slug      = var.use_naming
 }
 
-data "azurenoopsutils_resource_name" "bastion" {
+data "popsrox_utils_resource_name" "bastion" {
   name          = var.workload_name
   resource_type = "azurerm_bastion_host"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : module.mod_azregions.location_cli]
@@ -116,7 +116,7 @@ data "azurenoopsutils_resource_name" "bastion" {
   separator     = "-"
 }
 
-data "azurenoopsutils_resource_name" "bastion_pip" {
+data "popsrox_utils_resource_name" "bastion_pip" {
   name          = var.workload_name
   resource_type = "azurerm_public_ip"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : module.mod_azregions.location_cli]
@@ -126,7 +126,7 @@ data "azurenoopsutils_resource_name" "bastion_pip" {
   separator     = "-"
 }
 
-data "azurenoopsutils_resource_name" "ddos" {
+data "popsrox_utils_resource_name" "ddos" {
   name          = var.workload_name
   resource_type = "azurerm_network_ddos_protection_plan"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : module.mod_azregions.location_cli]
@@ -136,7 +136,7 @@ data "azurenoopsutils_resource_name" "ddos" {
   separator     = "-"
 }
 
-data "azurenoopsutils_resource_name" "pe" {
+data "popsrox_utils_resource_name" "pe" {
   name          = var.workload_name
   resource_type = "azurerm_private_endpoint"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : module.mod_azregions.location_cli]
@@ -146,7 +146,7 @@ data "azurenoopsutils_resource_name" "pe" {
   separator     = "-"
 }
 
-data "azurenoopsutils_resource_name" "psc" {
+data "popsrox_utils_resource_name" "psc" {
   name          = var.workload_name
   resource_type = "azurerm_private_service_connection"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : module.mod_azregions.location_cli]
@@ -156,7 +156,7 @@ data "azurenoopsutils_resource_name" "psc" {
   separator     = "-"
 }
 
-data "azurenoopsutils_resource_name" "nic" {
+data "popsrox_utils_resource_name" "nic" {
   name          = var.workload_name
   resource_type = "azurerm_network_interface"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azregions.location_short : module.mod_azregions.location_cli]

--- a/versions.tf
+++ b/versions.tf
@@ -12,9 +12,9 @@ terraform {
       source  = "hashicorp/azurerm"
       version = ">= 3.7.0, < 4.0"
     }
-    popsrox-utils = {
+    popsrox = {
       source  = "POps-Rox/azutils"
-      version = "~> 1.0.4"
+      version = "~> 1.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/versions.tf
+++ b/versions.tf
@@ -13,7 +13,7 @@ terraform {
       version = ">= 3.7.0, < 4.0"
     }
     popsrox-utils = {
-      source  = "POps-Rox/popsrox-utils"
+      source  = "POps-Rox/azutils"
       version = "~> 1.0.4"
     }
     random = {

--- a/versions.tf
+++ b/versions.tf
@@ -12,8 +12,8 @@ terraform {
       source  = "hashicorp/azurerm"
       version = ">= 3.7.0, < 4.0"
     }
-    azurenoopsutils = {
-      source  = "azurenoops/azurenoopsutils"
+    popsrox-utils = {
+      source  = "POps-Rox/popsrox-utils"
       version = "~> 1.0.4"
     }
     random = {


### PR DESCRIPTION
## Summary
Replace all `azurenoops/azurenoopsutils` provider references with `POps-Rox/popsrox-utils` across all .tf and .md files in the module.

## Changes
- `versions.tf`: Renamed provider key `azurenoopsutils` → `popsrox-utils`, updated source to `POps-Rox/popsrox-utils`
- `naming.tf`: All `data "azurenoopsutils_resource_name"` → `data "popsrox_utils_resource_name"`
- `locals.naming.tf`: All `data.azurenoopsutils_resource_name.` → `data.popsrox_utils_resource_name.`
- `modules.management.hub.nsg.tf`: Updated data source reference
- `modules.management.hub.snet.tf`: Updated data source reference
- `README.md` / `docs/index.md`: Updated registry badge and module URLs from `azurenoops` → `POps-Rox`
- 6 example `README.md` files: Updated `source` refs (including commented-out lines)

## Testing
- `grep -r azurenoops` returns no matches in .tf or .md files
- `terraform fmt -recursive` passes with exit code 0

Closes #13