### PR TITLE
fix: correct truncated module source slugs (tf-az-overlays → terraform-az-overlays)

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,10 +1,10 @@
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: tf-az-overlays-managementhub
+  name: terraform-az-overlays-managementhub
   description: Terraform overlay module for management hub virtual network
   annotations:
-    github.com/project-slug: POps-Rox/tf-az-overlays-managementhub
+    github.com/project-slug: POps-Rox/terraform-az-overlays-managementhub
     backstage.io/techdocs-ref: dir:.
   tags:
     - terraform
@@ -12,7 +12,7 @@ metadata:
     - azure
     - platform-ops
   links:
-    - url: https://github.com/POps-Rox/tf-az-overlays-managementhub
+    - url: https://github.com/POps-Rox/terraform-az-overlays-managementhub
       title: GitHub Repository
       icon: github
 spec:

--- a/examples/Commerical/hub_w_force_tunnel_and_ddos/main.tf
+++ b/examples/Commerical/hub_w_force_tunnel_and_ddos/main.tf
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 module "mod_vnet_hub" {
-  #source  = "github.com/POps-Rox/tf-az-overlays-managementhub"
+  #source  = "github.com/POps-Rox/terraform-az-overlays-managementhub"
   #version = "x.x.x"
   source = "../../.."
 

--- a/examples/Commerical/hub_w_force_tunnel_ddos_encrypted_transport/main.tf
+++ b/examples/Commerical/hub_w_force_tunnel_ddos_encrypted_transport/main.tf
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 module "mod_vnet_hub" {
-  #source  = "github.com/POps-Rox/tf-az-overlays-managementhub"
+  #source  = "github.com/POps-Rox/terraform-az-overlays-managementhub"
   #version = "x.x.x"
   source = "../../.."
 

--- a/examples/Commerical/hub_w_no_force_tunnel/main.tf
+++ b/examples/Commerical/hub_w_no_force_tunnel/main.tf
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 module "mod_vnet_hub" {
-  #source  = "github.com/POps-Rox/tf-az-overlays-managementhub"
+  #source  = "github.com/POps-Rox/terraform-az-overlays-managementhub"
   #version = "x.x.x"
   source = "../../.."
 

--- a/examples/Government/hub_w_force_tunnel_and_dns/main.tf
+++ b/examples/Government/hub_w_force_tunnel_and_dns/main.tf
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 module "mod_vnet_hub" {
-  #source  = "github.com/POps-Rox/tf-az-overlays-managementhub"
+  #source  = "github.com/POps-Rox/terraform-az-overlays-managementhub"
   #version = "x.x.x"
   source = "../../.."
 

--- a/examples/Government/hub_w_force_tunnel_and_dns_cmk/main.tf
+++ b/examples/Government/hub_w_force_tunnel_and_dns_cmk/main.tf
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 module "mod_vnet_hub" {
-  #source  = "github.com/POps-Rox/tf-az-overlays-managementhub"
+  #source  = "github.com/POps-Rox/terraform-az-overlays-managementhub"
   #version = "x.x.x"
   source = "../../.."
 

--- a/examples/Government/hub_w_no_force_tunnel/main.tf
+++ b/examples/Government/hub_w_no_force_tunnel/main.tf
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 module "mod_vnet_hub" {
-  #source  = "github.com/POps-Rox/tf-az-overlays-managementhub"
+  #source  = "github.com/POps-Rox/terraform-az-overlays-managementhub"
   #version = "x.x.x"
   source = "../../.."
 

--- a/module.management.hub.diagnostic.settings.tf
+++ b/module.management.hub.diagnostic.settings.tf
@@ -17,7 +17,7 @@ AUTHOR/S: jrspinella
 ##############################################
 
 module "mod_vnet_diagnostic_settings" {
-  source = "github.com/POps-Rox/tf-az-overlays-diagnosticsettings"
+  source = "github.com/POps-Rox/terraform-az-overlays-diagnosticsettings"
 
   count = var.existing_log_analytics_workspace_resource_id != null ? 1 : 0
 
@@ -34,7 +34,7 @@ module "mod_vnet_diagnostic_settings" {
 }
 
 module "mod_nsg_diagnostic_settings" {
-  source = "github.com/POps-Rox/tf-az-overlays-diagnosticsettings"
+  source = "github.com/POps-Rox/terraform-az-overlays-diagnosticsettings"
 
   for_each = toset(var.existing_log_analytics_workspace_resource_id != null ? [var.hub_subnets] : [])
 

--- a/modules.management.hub.dns.tf
+++ b/modules.management.hub.dns.tf
@@ -9,7 +9,7 @@ AUTHOR/S: jrspinella
 */
 
 module "mod_default_pdz" {
-  source     = "github.com/POps-Rox/tf-az-overlays-privatednszone"
+  source     = "github.com/POps-Rox/terraform-az-overlays-privatednszone"
   depends_on = [module.mod_dns_rg]
 
   for_each = toset(var.enable_private_dns_zones ? [concat(local.if_default_private_dns_zones_enabled, var.private_dns_zones)] : [])

--- a/modules.management.hub.scaffolding.tf
+++ b/modules.management.hub.scaffolding.tf
@@ -6,7 +6,7 @@
 #--------------------------------------
 # This module will lookup the Azure Region and return the short name for the region
 module "mod_azregions" {
-  source = "github.com/POps-Rox/tf-az-overlays-azregionslookup"
+  source = "github.com/POps-Rox/terraform-az-overlays-azregionslookup"
 
   azure_region = var.location
 }
@@ -23,7 +23,7 @@ data "azurerm_resource_group" "rgrp" {
 }
 
 module "mod_scaffold_rg" {
-  source = "github.com/POps-Rox/tf-az-overlays-resourcegroup"
+  source = "github.com/POps-Rox/terraform-az-overlays-resourcegroup"
 
   count = var.create_hub_resource_group ? 1 : 0
 
@@ -42,7 +42,7 @@ module "mod_scaffold_rg" {
 # Private DNS Zone RG
 #----------------------------------------
 module "mod_dns_rg" {
-  source = "github.com/POps-Rox/tf-az-overlays-resourcegroup"
+  source = "github.com/POps-Rox/terraform-az-overlays-resourcegroup"
 
   count = var.enable_private_dns_zones && length(var.private_dns_zones) > 0 ? 1 : 0
 


### PR DESCRIPTION
## Summary
GitHub renamed these repos from `tf-az-overlays-*` to `terraform-az-overlays-*` in a prior cleanup, but module `source =` references in `.tf` files and `catalog-info.yaml` annotations still use the old slug. Terraform module downloads currently succeed only via GitHub's 301 redirect — fragile and prone to break.

## Changes
- All `.tf` files: `POps-Rox/tf-az-overlays-*` → `POps-Rox/terraform-az-overlays-*`
- All `.tf` files: `POps-Rox/tf-az-entra-overlays-*` → `POps-Rox/terraform-az-entra-overlays-*`
- `catalog-info.yaml`: `metadata.name` and `github.com/project-slug` annotation updated to match actual repo name

## Validation
```bash
grep -rln 'POps-Rox/tf-az-overlays\|pops-rox/tf-az-overlays' --include='*.tf' .
grep -l 'tf-az-overlays\|tf-az-entra-overlays' catalog-info.yaml
```
Both return no output after this PR.

Part of the POps-Rox Go-To-Market initiative.